### PR TITLE
Update naming of image

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -81,7 +81,7 @@ public class PersonCard extends UiPart<Region> {
         telegramIcon.setImage(telegramImage);
         applyWhiteColorEffect(telegramIcon);
 
-        Image githubImage = new Image(getClass().getResourceAsStream("/images/github.png"));
+        Image githubImage = new Image(getClass().getResourceAsStream("/images/Github.png"));
         githubIcon.setImage(githubImage);
         applyWhiteColorEffect(githubIcon);
 


### PR DESCRIPTION
- Fixes #204 
- Fixes #198
- Fixes #197
- Fixes #174
- Fixes #173
- Fixes #172
- Fixes #169 
- Fixes #162
- Fixes #201
## Implementation
A file was referring to image as `github.png` but actual file was `Github.png`. For some reason it works on IDE but not on JAR file