### PR TITLE
Allow creating team with no person

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CreateTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateTeamCommandParser.java
@@ -28,7 +28,7 @@ public class CreateTeamCommandParser implements Parser<CreateTeamCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TEAM_NAME, PREFIX_HACKATHON, PREFIX_PERSON);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_TEAM_NAME, PREFIX_HACKATHON, PREFIX_PERSON)
+        if (!arePrefixesPresent(argMultimap, PREFIX_TEAM_NAME, PREFIX_HACKATHON)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateTeamCommand.MESSAGE_USAGE));
         }


### PR DESCRIPTION
## Context
- Closes #208

## Implementation
Now I can create an empty team. This standardised behaviour throughout MATE. 
With regards to #208, if the team only has a person and then I proceed to to delete that person, then the team will not be deleted because now I allow empty teams.